### PR TITLE
cmake: include statements in tests module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ if (APPLE)
     add_compile_options(
             "-Wno-error=unused-command-line-argument"
     )
-    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 endif()
 
 # using C++ 17

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,9 @@ project(MyRPGGame)
 add_subdirectory(MyRPGGame/core)
 add_subdirectory(MyRPGGame/tests)
 
+set(CORE_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/MyRPGGame/core/include)
+target_include_directories(tests PUBLIC ${CORE_INCLUDE_DIR})
+
 # use C++ 17 compilation features - can be good for templates, overriding constructors, etc.
 target_compile_features(main PRIVATE cxx_std_17)
 set_property(TARGET main PROPERTY COMPILE_WARNING_AS_ERROR OFF)

--- a/MyRPGGame/core/CMakeLists.txt
+++ b/MyRPGGame/core/CMakeLists.txt
@@ -46,7 +46,7 @@ target_link_libraries(main_lib sfml-system
 if (WIN32)
 
     add_custom_command(
-            TARGET main
+            TARGET main_lib
             COMMENT "Copy OpenAL DLL"
             PRE_BUILD COMMAND ${CMAKE_COMMAND} -E copy ${SFML_SOURCE_DIR}/extlibs/bin/$<IF:$<EQUAL:${CMAKE_SIZEOF_VOID_P},8>,x64,x86>/openal32.dll $<TARGET_FILE_DIR:main_lib>
             VERBATIM)

--- a/MyRPGGame/tests/CMakeLists.txt
+++ b/MyRPGGame/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(tests ${TESTS_SOURCE_FILES})
 
 # linking the core library to the tests executable
 target_link_libraries(tests PRIVATE main_lib)
+target_include_directories(tests PRIVATE ${CORE_INCLUDE_DIR})
 
 # adding googletest as submodule w/o installing it
 set(INSTALL_GTEST OFF)


### PR DESCRIPTION
include statements in tests module can be used just like in core module.
executable location is now under bin folder in build, i.e: build/bin